### PR TITLE
Potential fix for code scanning alert no. 6: Prototype-polluting function

### DIFF
--- a/src/util/general.ts
+++ b/src/util/general.ts
@@ -2,9 +2,12 @@
 export function deepMerge(target: any, source: any): any {
     for (const key in source) {
         if (Object.prototype.hasOwnProperty.call(source, key)) {
+            if (key === '__proto__' || key === 'constructor') {
+                continue; // Skip prototype-polluting keys
+            }
             if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
                 if (!target[key]) {
-                    target[key] = {};
+                   target[key] = {};
                 }
                 deepMerge(target[key], source[key]);
             } else {


### PR DESCRIPTION
Potential fix for [https://github.com/tobrien/gmexport/security/code-scanning/6](https://github.com/tobrien/gmexport/security/code-scanning/6)

To fix the issue, we need to explicitly block the special property names `__proto__` and `constructor` from being copied from the `source` object to the `target` object. This can be achieved by adding a condition to skip these property names during the merge process. This approach ensures that the function remains safe from prototype pollution while preserving its intended functionality.

The changes will be made in the `deepMerge` function in `src/util/general.ts`:
1. Add a condition to skip keys named `__proto__` or `constructor` during the merge process.
2. Ensure that this condition is checked before any recursive calls or assignments.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
