### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
       - 'release/**'
       - 'feature/**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tobrien/gmexport/security/code-scanning/2](https://github.com/tobrien/gmexport/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions required. Based on the workflow's operations, the minimal required permission is `contents: read`, as the workflow only needs to read repository contents to run tests, lint, build, and upload coverage reports. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
